### PR TITLE
Use 24 bit colors

### DIFF
--- a/core/scene.erl
+++ b/core/scene.erl
@@ -23,10 +23,10 @@ render_message(warning, Title, Text) ->
 
 render_message(Icon, Title, Text) ->
     [
-        {clear_screen, 16#CE59},
-        {rect, 0, 0, 320, 18, 16#0010},
-        {text, 1, 1, Title, 16#FFFF},
-        {image, 1, 80, Icon, 16#CE59},
+        {clear_screen, 16#C8C8C8},
+        {rect, 0, 0, 320, 18, 16#000080},
+        {text, 1, 1, Title, 16#FFFFFF},
+        {image, 1, 80, Icon, 16#C8C8C8},
         {text, 70, 103, Text, 16#00}
     ].
 
@@ -38,20 +38,20 @@ render_options([], _Selected, _Index) ->
 
 render_options([Text | Options], Selected, Index) when Selected == Index ->
     [
-        {rect, 0, 18 * Index, 320, 18, 16#0010},
-        {text, 1, 18 * Index + 1, Text, 16#FFFF} |
+        {rect, 0, 18 * Index, 320, 18, 16#000080},
+        {text, 1, 18 * Index + 1, Text, 16#FFFFFF} |
         render_options(Options, Selected, Index + 1)
     ];
 
 render_options([Text | Options], Selected, Index) ->
     BackColor =
         case Index rem 2 of
-            0 -> 16#E73C;
-            1 -> 16#D69A
+            0 -> 16#E0E4E0;
+            1 -> 16#D0D0D0
         end,
     [
         {rect, 0, 18 * Index, 320, 18, BackColor},
-        {text, 1, 18 * Index + 1, Text, 16#0000} |
+        {text, 1, 18 * Index + 1, Text, 16#000000} |
         render_options(Options, Selected, Index + 1)
     ].
 

--- a/esp32/components/ihc-2020-badge/display_driver.c
+++ b/esp32/components/ihc-2020-badge/display_driver.c
@@ -420,7 +420,7 @@ static void process_message(Message *message, Context *ctx)
     if (cmd == context_make_atom(ctx, "\xC" "clear_screen")) {
         int color = term_to_int(term_get_tuple_element(req, 1));
 
-        clear_screen(spi, (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+        clear_screen(spi, (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
     } else if (cmd == context_make_atom(ctx, "\xA" "draw_image")) {
         int x = term_to_int(term_get_tuple_element(req, 1));
@@ -432,7 +432,7 @@ static void process_message(Message *message, Context *ctx)
         int height = term_to_int(term_get_tuple_element(img, 1));
         const char *data = term_binary_data(term_get_tuple_element(img, 2));
 
-        draw_image(spi, x, y, width, height, data, (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+        draw_image(spi, x, y, width, height, data, (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
     } else if (cmd == context_make_atom(ctx, "\xB" "draw_buffer")) {
         int x = term_to_int(term_get_tuple_element(req, 1));
@@ -457,7 +457,7 @@ static void process_message(Message *message, Context *ctx)
         int color = term_to_int(term_get_tuple_element(req, 5));
 
         draw_rect(spi, x, y, width, height,
-                (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+                (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
     } else if (cmd == context_make_atom(ctx, "\x9" "draw_text")) {
         int x = term_to_int(term_get_tuple_element(req, 1));
@@ -468,7 +468,7 @@ static void process_message(Message *message, Context *ctx)
         int ok;
         char *text = interop_term_to_string(text_term, &ok);
 
-        draw_text(spi, x, y, text, (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+        draw_text(spi, x, y, text, (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
         free(text);
 

--- a/simulator/display.c
+++ b/simulator/display.c
@@ -146,8 +146,8 @@ static void process_message(Context *ctx)
         int height = term_to_int(term_get_tuple_element(img, 1));
         const char *data = term_binary_data(term_get_tuple_element(img, 2));
 
-        draw_image(screen, x, y, width, height, data, (color >> 11) << 3,
-                ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+        draw_image(screen, x, y, width, height, data, (color >> 16),
+                (color >> 8) & 0xFF, color & 0xFF);
 
     } else if (cmd == context_make_atom(ctx, "\x9" "draw_rect")) {
         int x = term_to_int(term_get_tuple_element(req, 1));
@@ -157,7 +157,7 @@ static void process_message(Context *ctx)
         int color = term_to_int(term_get_tuple_element(req, 5));
 
         draw_rect(screen, x, y, width, height,
-                (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+                (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
     } else if (cmd == context_make_atom(ctx, "\x9" "draw_text")) {
         int x = term_to_int(term_get_tuple_element(req, 1));
@@ -168,7 +168,7 @@ static void process_message(Context *ctx)
         int ok;
         char *text = interop_term_to_string(text_term, &ok);
 
-        draw_text(screen, x, y, text, (color >> 11) << 3, ((color >> 5) & 0x3F) << 2, (color & 0x1F) << 3);
+        draw_text(screen, x, y, text, (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 
         free(text);
 


### PR DESCRIPTION
24 colors have no overhead (no boxed integers are required) and are easier
to pick than 16 bit colors.
The ESP32 display driver will care about conversion.